### PR TITLE
コンペティションが開催していなかったらアノテーションの候補取得・登録が出来ないようにする

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -63,6 +63,17 @@ class AssignmentsController < ApplicationController
   end
 
   def new
+    # コンペティションが開催中か確認
+    count_running_competition = Competition.
+                                  where('starts_at < ?', Time.current).
+                                  where('ends_at > ?', Time.current).
+                                  count
+
+    if count_running_competition == 0
+      render json: {message: 'no competition is running'}, status: 200
+      return
+    end
+
     # FIXME 送信されてきたデータのバリデーションを追加
     annotations = params[:annotations].map do |annotation|
       {assignment_id: annotation[:assignmentId].to_i,

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -2,6 +2,17 @@ class AssignmentsController < ApplicationController
   before_action :authenticate_user!, only: [:show, :new]
 
   def show
+    # コンペティションが開催中か確認
+    count_running_competition = Competition.
+                                  where('starts_at < ?', Time.current).
+                                  where('ends_at > ?', Time.current).
+                                  count
+
+    if count_running_competition == 0
+      render json: {message: 'no competition is running'}, status: 200
+      return
+    end
+
     sql = <<-SQL
       WITH assignments_without_annotation AS (
         SELECT

--- a/spec/requests/assignments_request_spec.rb
+++ b/spec/requests/assignments_request_spec.rb
@@ -3,8 +3,16 @@ require 'rails_helper'
 RSpec.describe "Assignments", type: :request do
 
   describe "GET /assignment" do
-    it "returns http success" do
-      assignment = create(:assignment)
+    it "returns http success and array if competition is running" do
+      assignment = build(:assignment)
+      competition = assignment.competition
+
+      # 開催中のコンペが存在
+      competition.starts_at = Time.current.advance(days: -1)
+      competition.ends_at = Time.current.advance(days: 2)
+      assignment.save!
+      competition.save!
+
       user = create(:user)
       image = assignment.image
       auth_token = sign_in_through_api(user)
@@ -16,6 +24,26 @@ RSpec.describe "Assignments", type: :request do
       expect(assignments.first['imageUrl']).to eq image.url
 
       expect(Assignment.find(assignment.id).user).to eq(user)
+    end
+
+    it "returns dict if competition is not running" do
+      assignment = build(:assignment)
+      # コンペは開催していない
+      competition = assignment.competition
+      competition.starts_at = Time.current.advance(days: 1)
+      competition.ends_at = Time.current.advance(days: 2)
+      assignment.save!
+      competition.save!
+
+      user = create(:user)
+      auth_token = sign_in_through_api(user)
+
+      get "/assignment", headers: auth_token
+
+      expect(response).to have_http_status(:success)
+
+      assignments = JSON.parse(response.body)
+      expect(assignments["message"]).to eq 'no competition is running'
     end
   end
 

--- a/spec/requests/assignments_request_spec.rb
+++ b/spec/requests/assignments_request_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "Assignments", type: :request do
 
     it "returns dict if competition is not running" do
       assignment = build(:assignment)
+
       # コンペは開催していない
       competition = assignment.competition
       competition.starts_at = Time.current.advance(days: 1)
@@ -49,19 +50,55 @@ RSpec.describe "Assignments", type: :request do
 
   describe "POST /assignment" do
     it "returns http success and add new record" do
-      assignment = create(:assignment)
+      assignment = build(:assignment)
+
+      # 開催中のコンペが存在
+      competition = assignment.competition
+      competition.starts_at = Time.current.advance(days: -1)
+      competition.ends_at = Time.current.advance(days: 2)
+      assignment.save!
+      competition.save!
+
       user = create(:user)
       annotation_label = create(:annotation_label)
       auth_token = sign_in_through_api(user)
 
       expect(Annotation.count).to eq(0)
 
-      annotations = [{assignmentId: assignment.id, annotation: annotation_label.id}]
-      post "/assignment", params: {annotations: annotations}, headers: auth_token
+      annotations = [{assignmentId: assignment.id,
+                      annotation: annotation_label.id}]
+      post "/assignment",
+           params: {annotations: annotations},
+           headers: auth_token
       expect(response).to have_http_status(:success)
 
       expect(Annotation.count).to eq(1)
     end
-  end
 
+    it "returns 200 but no record added if no competition is running" do
+      assignment = build(:assignment)
+
+      # 開催中のコンペはない
+      competition = assignment.competition
+      competition.starts_at = Time.current.advance(days: 1)
+      competition.ends_at = Time.current.advance(days: 2)
+      assignment.save!
+      competition.save!
+
+      user = create(:user)
+      annotation_label = create(:annotation_label)
+      auth_token = sign_in_through_api(user)
+
+      expect(Annotation.count).to eq(0)
+
+      annotations = [{assignmentId: assignment.id,
+                      annotation: annotation_label.id}]
+      post "/assignment",
+           params: {annotations: annotations},
+           headers: auth_token
+      expect(response).to have_http_status(:success)
+
+      expect(Annotation.count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
## WHY
* コンペティション開催中以外にアノテーションされてしまうと困るため
ref #19 

## WHAT
* コンペティションが開催していなかったら，
  * アノテーションの候補を取得できないように変更
  * アノテーションの登録が出来ないように変更
* テストを追加・修正